### PR TITLE
Add `.vscode/settings.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/settings.json
 node_modules
 *.vsix
 dist


### PR DESCRIPTION
For instance, I have [Prettier](https://prettier.io/) enabled globally, so for this repo I had to put this in `.vscode/settings.json`, but I didn't want to commit it to the repo:

```json
{ "[typescript]": { "editor.formatOnSave": false } }
```