### PR TITLE
Add `wat.trace.server` configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,17 @@
           "type": "string",
           "default": "",
           "ignoreSync": true
+        },
+        "wat.trace.server": {
+          "description": "Traces the communication between VS Code and the language server.",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "scope": "window"
         }
       }
     },


### PR DESCRIPTION
This is helpful for debugging the language server. According to [the docs](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server):

> If you are using `vscode-languageclient` to implement the client, you can specify a setting `[langId].trace.server` that instructs the Client to log communications between Language Client / Server to a channel of the Language Client's `name`.

In this case, the language ID is `wat`:

https://github.com/g-plane/vscode-wasm/blob/aed44c13faa190161a06d0b99d4e9a2a1979c3b6/package.json#L34

So, the setting must be named `wat.trace.server`.